### PR TITLE
Add initial environment file for conda

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -7,6 +7,7 @@ channels:
   - defaults
 dependencies:
   - python=3.8
+  - libopencv
   - pip
   - torchvision
   - pytorch


### PR DESCRIPTION
I made a file to setup the conda environment, adding ROS stuff from the robostack that should help for the future robot integration.

There is just one issue: if we aim to install [leggedrobotics' sour tego](https://github.com/leggedrobotics/stego) fork directly using pip in the YAML file, it doesn't work. If I run `pip install -e ./stego` as recommended in the README it works though.

My only guess to explain this is that stego is using the `setup` method from `distutils` while all the other packages (kornia, liegroups, pydensecrf) use the one from `setuptools`. @JonasFrey96 do you have any clue?