### PR TITLE
Fix dataset generation delay spotted by Robin

### DIFF
--- a/wild_visual_navigation/utils/operation_modes.py
+++ b/wild_visual_navigation/utils/operation_modes.py
@@ -2,13 +2,13 @@ from enum import Enum
 
 
 class WVNMode(Enum):
-    DEAFULT = 0
+    DEFAULT = 0
     ONLINE = 1
     EXTRACT_LABELS = 2
 
     def from_string(string):
         if string == "default":
-            return WVNMode.DEAFULT
+            return WVNMode.DEFAULT
         elif string == "online":
             return WVNMode.ONLINE
         elif string == "extract_labels":

--- a/wild_visual_navigation_ros/scripts/wild_visual_navigation_node.py
+++ b/wild_visual_navigation_ros/scripts/wild_visual_navigation_node.py
@@ -337,12 +337,13 @@ class WvnRosInterface:
 
         if stamp is None:
             stamp = rospy.Time(0)
-        # Wait for required tfs
-        try:
-            self.tf_listener.waitForTransform(parent_frame, child_frame, stamp, rospy.Duration(1.0))
-        except Exception as e:
-            print("Error in querry tf: ", e)
-            return (None, None)
+        # Wait for required tfs - Only done if we are not extracting labels
+        if self.mode != WVNMode.EXTRACT_LABELS:
+            try:
+                self.tf_listener.waitForTransform(parent_frame, child_frame, stamp, rospy.Duration(1.0))
+            except Exception as e:
+                print("Error in querry tf: ", e)
+                return (None, None)
 
         try:
             (trans, rot) = self.tf_listener.lookupTransform(parent_frame, child_frame, stamp)


### PR DESCRIPTION
This minor change should enable `waitForTransform` for all the cases but when we are extracting labels (i.e dataset generation), addressing https://github.com/leggedrobotics/wild_visual_navigation/issues/147

@schmirob since you are using this feature these days would you mind testing this small change? Then we can merge