### PR TITLE
Simple fix for the confidence

### DIFF
--- a/tests/test_confidence_generator.py
+++ b/tests/test_confidence_generator.py
@@ -111,7 +111,7 @@ def test_confidence_generator():
     # Naive loss distribution mean
     axs[1].fill_between(
         t_np,
-        t_np*0.0,
+        t_np * 0.0,
         loss_mean_np[0] + sigma_factor * loss_std_np[0],
         alpha=0.2,
         label=f"Loss mean $\pm{sigma_factor}\sigma$",
@@ -120,7 +120,7 @@ def test_confidence_generator():
 
     axs[1].fill_between(
         t_np,
-        t_np*0.0,
+        t_np * 0.0,
         loss_mean_np[0] + loss_std_np[0],
         alpha=0.6,
         label="Loss mean $\pm\sigma$",

--- a/wild_visual_navigation/utils/confidence_generator.py
+++ b/wild_visual_navigation/utils/confidence_generator.py
@@ -80,7 +80,7 @@ class ConfidenceGenerator(torch.nn.Module):
 
             assert torch.isnan(self.mean).any() == False, "Nan Value in mean detected"
         self.std[0] = torch.sqrt(self.var)[0, 0]
-        
+
         # Then the confidence is computed as the distance to the center of the Gaussian given factor*sigma
         confidence = torch.exp(-(((x - self.mean) / (2 * self.std * self.std_factor)) ** 2))
         confidence[x < self.mean] = 1.0


### PR DESCRIPTION
Maybe this fixes what we discussed without the sigmoid but perhaps it's also wrong. It's late :)

```python
confidence = torch.exp(-(((x - self.mean) / (2 * self.std * self.std_factor)) ** 2))
confidence[x < self.mean] = 1.0
```