### PR TITLE
Implemented Cumsum trick by default off

### DIFF
--- a/wild_visual_navigation_ros/config/wild_visual_navigation/inputs/alphasense_compressed.yaml
+++ b/wild_visual_navigation_ros/config/wild_visual_navigation/inputs/alphasense_compressed.yaml
@@ -1,0 +1,17 @@
+camera_topics:
+  front:
+    image_topic: "/alphasense_driver_ros/cam4/debayered/compressed"
+    info_topic: "/alphasense_driver_ros/cam4/camera_info"
+    use_for_training: true
+  # left:
+  #   image_topic: "/alphasense_driver_ros/cam3/debayered"
+  #   info_topic: "/alphasense_driver_ros/cam3/camera_info"
+  #   use_for_training: false
+  # right:
+  #   image_topic: "/alphasense_driver_ros/cam5/debayered"
+  #   info_topic: "/alphasense_driver_ros/cam5/camera_info"
+  #   use_for_training: false
+
+# Provides 1080 (height) x 1920 (width) images
+network_input_image_height: 224 # 448
+network_input_image_width: 224 # 448


### PR DESCRIPTION
Takes 20ms for 100 segments constant with number of features.
Old implementation iterating over the features took 8ms-22ms, therefore I turned it now off by default. 

Added for replay a yaml file with the compressed alpha sense image topics.