### PR TITLE
Add pre-commit for large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,8 @@ repos:
         stages: [commit]
         language: system
         entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0 # Use the version you want
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=2000"]


### PR DESCRIPTION
This solves https://github.com/leggedrobotics/wild_visual_navigation/issues/252 (which was closed but not really addressed)

@JonasFrey96 FYI I set the limit to 2mb