### PR TITLE
Check if the debug image has not been deleted before publishing

### DIFF
--- a/wild_visual_navigation/traversability_estimator/nodes.py
+++ b/wild_visual_navigation/traversability_estimator/nodes.py
@@ -163,6 +163,10 @@ class MissionNode(BaseNode):
             print(e)
             pass  # Image already removed
 
+    def has_debug_data(self):
+        return hasattr(self, "_image") and self._image is not None and \
+            hasattr(self, "_supervision_mask") and self._supervision_mask is not None
+
     def change_device(self, device):
         """Changes the device of all the class members
 

--- a/wild_visual_navigation/traversability_estimator/nodes.py
+++ b/wild_visual_navigation/traversability_estimator/nodes.py
@@ -164,8 +164,12 @@ class MissionNode(BaseNode):
             pass  # Image already removed
 
     def has_debug_data(self):
-        return hasattr(self, "_image") and self._image is not None and \
-            hasattr(self, "_supervision_mask") and self._supervision_mask is not None
+        return (
+            hasattr(self, "_image")
+            and self._image is not None
+            and hasattr(self, "_supervision_mask")
+            and self._supervision_mask is not None
+        )
 
     def change_device(self, device):
         """Changes the device of all the class members

--- a/wild_visual_navigation_ros/scripts/wvn_learning_node.py
+++ b/wild_visual_navigation_ros/scripts/wvn_learning_node.py
@@ -831,7 +831,7 @@ class WvnLearning:
         vis_node = self._traversability_estimator.get_mission_node_for_visualization()
 
         # Publish reprojections of last node in graph
-        if vis_node is not None:
+        if vis_node is not None and vis_node.has_debug_data():
             cam = vis_node.camera_name
             torch_image = vis_node._image
             torch_mask = vis_node._supervision_mask
@@ -840,6 +840,9 @@ class WvnLearning:
 
             image_out = self._visualizer.plot_detectron_classification(torch_image, torch_mask, cmap="Blues")
             self._camera_handler[cam]["debug"]["image_overlay"].publish(rc.numpy_to_ros_image(image_out))
+
+        elif vis_node is not None:
+            rospy.logwarn(f"[{self._node_name}] No visualization data available for node")
 
     def pause_learning_callback(self, req):
         """Start and stop the network training"""


### PR DESCRIPTION
Add a check before publishing the debug image.

The debug image might be deleted in the [traversability estimator](https://github.com/leggedrobotics/wild_visual_navigation/blob/8b9caf915e668653b761b57ed33d2719a38b4bfd/wild_visual_navigation/traversability_estimator/traversability_estimator.py#L244). If no new mission nodes are created in 30 seconds, this may lead to an error if the debug image publication is enabled.